### PR TITLE
don't prefix upper case libraryNames with -

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -126,8 +126,9 @@ var AngularjsLibraryGenerator = yeoman.generators.Base.extend({
           camelized: this._.camelize(this._.underscored(props.libraryName)),
 
           // Dasherized (underscored and camelized to dashes) => project-angular-library
-          // convert to lowercase to avoid prefixing - when upper case libraryName
-          dasherized: this._.dasherize(props.libraryName.toLowerCase()),
+          // issue 28: convert 1st char of libraryName to lowercase to avoid prefixing '-'
+          //  after upgrading library could just replace with decapitalize()
+          dasherized: this._.dasherize(props.libraryName.charAt(0).toLowerCase() + props.libraryName.slice(1)),
 
           // Slugified (whitespace and special chars replaced by dashes (great for url's)) => project-angular-library
           slugified: this._.slugify(props.libraryName),

--- a/app/index.js
+++ b/app/index.js
@@ -126,7 +126,8 @@ var AngularjsLibraryGenerator = yeoman.generators.Base.extend({
           camelized: this._.camelize(this._.underscored(props.libraryName)),
 
           // Dasherized (underscored and camelized to dashes) => project-angular-library
-          dasherized: this._.dasherize(props.libraryName),
+          // convert to lowercase to avoid prefixing - when upper case libraryName
+          dasherized: this._.dasherize(props.libraryName.toLowerCase()),
 
           // Slugified (whitespace and special chars replaced by dashes (great for url's)) => project-angular-library
           slugified: this._.slugify(props.libraryName),
@@ -142,9 +143,9 @@ var AngularjsLibraryGenerator = yeoman.generators.Base.extend({
         includeAngularModuleSanitize: props.includeAngularModuleSanitize
       };
 
-      this.props.librarySrcDirectory = 'src' + '/' + this.props.libraryName.slugified;
-      this.props.libraryUnitTestDirectory = 'test' + '/unit/' + this.props.libraryName.slugified;
-      this.props.libraryUnitE2eDirectory = 'test' + '/e2e/' + this.props.libraryName.slugified;
+      this.props.librarySrcDirectory = 'src' + '/' + this.props.libraryName.dasherized;
+      this.props.libraryUnitTestDirectory = 'test' + '/unit/' + this.props.libraryName.dasherized;
+      this.props.libraryUnitE2eDirectory = 'test' + '/e2e/' + this.props.libraryName.dasherized;
 
       this.config.set('props', this.props);
 

--- a/app/index.js
+++ b/app/index.js
@@ -142,9 +142,9 @@ var AngularjsLibraryGenerator = yeoman.generators.Base.extend({
         includeAngularModuleSanitize: props.includeAngularModuleSanitize
       };
 
-      this.props.librarySrcDirectory = 'src' + '/' + this.props.libraryName.dasherized;
-      this.props.libraryUnitTestDirectory = 'test' + '/unit/' + this.props.libraryName.dasherized;
-      this.props.libraryUnitE2eDirectory = 'test' + '/e2e/' + this.props.libraryName.dasherized;
+      this.props.librarySrcDirectory = 'src' + '/' + this.props.libraryName.slugified;
+      this.props.libraryUnitTestDirectory = 'test' + '/unit/' + this.props.libraryName.slugified;
+      this.props.libraryUnitE2eDirectory = 'test' + '/e2e/' + this.props.libraryName.slugified;
 
       this.config.set('props', this.props);
 

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -18,6 +18,9 @@ var rootDirectory = path.resolve('./');
 // Source directory for build process
 var sourceDirectory = path.join(rootDirectory, './src');
 
+// tests
+var testDirectory = path.join(rootDirectory, './test/unit');
+
 var sourceFiles = [
 
   // Make sure module files are handled first
@@ -57,6 +60,9 @@ gulp.task('watch', function () {
 
   // Watch JavaScript files
   gulp.watch(sourceFiles, ['process-all']);
+
+  // watch test files and re-run unit tests when changed
+  gulp.watch(path.join(testDirectory, '/**/*.js'), ['test-src']);
 });
 
 /**


### PR DESCRIPTION
This change is to address issue/28. this._.dasherize() prefixes upper case libraryName with - . e.g. "My New Library" became -my-new-library. So my solution is to convert the libraryName to lowercase before calling dasherize.